### PR TITLE
Add Logger ability to contacts API

### DIFF
--- a/core/src/main/java/contacts/core/Contacts.kt
+++ b/core/src/main/java/contacts/core/Contacts.kt
@@ -10,6 +10,7 @@ import contacts.core.entities.custom.CustomDataRegistry
 import contacts.core.groups.Groups
 import contacts.core.log.EmptyLogger
 import contacts.core.log.Logger
+import contacts.core.log.LoggerRegistry
 import contacts.core.profile.Profile
 
 /**
@@ -43,8 +44,6 @@ import contacts.core.profile.Profile
  * For accounts operations, use [accounts].
  */
 interface Contacts {
-
-    var logger: Logger
 
     /**
      * Returns a new [Query] instance.
@@ -141,6 +140,11 @@ interface Contacts {
      * Registry for all [CrudApi.Listener]s.
      */
     val apiListenerRegistry: CrudApiListenerRegistry
+
+    /**
+     * Registry for [Logger]
+     */
+    var loggerRegistry: LoggerRegistry
 }
 
 /**
@@ -150,16 +154,16 @@ interface Contacts {
 @Suppress("FunctionName")
 fun Contacts(
     context: Context,
-    logger: Logger = EmptyLogger(),
     customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
-    apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
+    apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry(),
+    loggerRegistry: LoggerRegistry = LoggerRegistry(),
 ): Contacts = ContactsImpl(
     context.applicationContext,
     ContactsPermissions(context.applicationContext),
     AccountsPermissions(context.applicationContext),
     customDataRegistry,
-    apiListenerRegistry,
-    logger,
+    apiListenerRegistry.register(loggerRegistry.apiListener),
+    loggerRegistry,
 )
 
 /**
@@ -174,10 +178,10 @@ object ContactsFactory {
     @JvmOverloads
     fun create(
         context: Context,
-        logger: Logger = EmptyLogger(),
+        loggerRegistry: LoggerRegistry = LoggerRegistry(),
         customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
         apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
-    ): Contacts = Contacts(context, logger, customDataRegistry, apiListenerRegistry)
+    ): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry, loggerRegistry)
 }
 
 private class ContactsImpl(
@@ -186,7 +190,7 @@ private class ContactsImpl(
     override val accountsPermissions: AccountsPermissions,
     override val customDataRegistry: CustomDataRegistry,
     override val apiListenerRegistry: CrudApiListenerRegistry,
-    override var logger: Logger,
+    override var loggerRegistry: LoggerRegistry,
 ) : Contacts {
 
     override fun query() = Query(this)

--- a/core/src/main/java/contacts/core/Contacts.kt
+++ b/core/src/main/java/contacts/core/Contacts.kt
@@ -156,15 +156,26 @@ fun Contacts(
     context: Context,
     customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
     apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry(),
+    logger: Logger = EmptyLogger(),
+): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry, LoggerRegistry(logger))
+
+/**
+ * Creates a new [Contacts] instance.
+ */
+@Suppress("FunctionName")
+fun Contacts(
+    context: Context,
+    customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
+    apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry(),
     loggerRegistry: LoggerRegistry = LoggerRegistry(),
 ): Contacts = ContactsImpl(
-    context.applicationContext,
-    ContactsPermissions(context.applicationContext),
-    AccountsPermissions(context.applicationContext),
-    customDataRegistry,
-    apiListenerRegistry.register(loggerRegistry.apiListener),
-    loggerRegistry,
-)
+        context.applicationContext,
+        ContactsPermissions(context.applicationContext),
+        AccountsPermissions(context.applicationContext),
+        customDataRegistry,
+        apiListenerRegistry.register(loggerRegistry.apiListener),
+        loggerRegistry,
+    )
 
 /**
  * Creates a new [Contacts] instance.
@@ -176,6 +187,14 @@ object ContactsFactory {
 
     @JvmStatic
     @JvmOverloads
+    fun create(
+        context: Context,
+        logger: Logger = EmptyLogger(),
+        customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
+        apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
+    ): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry, logger)
+
+    @JvmStatic
     fun create(
         context: Context,
         loggerRegistry: LoggerRegistry = LoggerRegistry(),

--- a/core/src/main/java/contacts/core/Contacts.kt
+++ b/core/src/main/java/contacts/core/Contacts.kt
@@ -8,6 +8,8 @@ import contacts.core.accounts.AccountsPermissions
 import contacts.core.data.Data
 import contacts.core.entities.custom.CustomDataRegistry
 import contacts.core.groups.Groups
+import contacts.core.log.EmptyLogger
+import contacts.core.log.Logger
 import contacts.core.profile.Profile
 
 /**
@@ -41,6 +43,8 @@ import contacts.core.profile.Profile
  * For accounts operations, use [accounts].
  */
 interface Contacts {
+
+    var logger: Logger
 
     /**
      * Returns a new [Query] instance.
@@ -146,6 +150,7 @@ interface Contacts {
 @Suppress("FunctionName")
 fun Contacts(
     context: Context,
+    logger: Logger = EmptyLogger(),
     customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
     apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
 ): Contacts = ContactsImpl(
@@ -153,7 +158,8 @@ fun Contacts(
     ContactsPermissions(context.applicationContext),
     AccountsPermissions(context.applicationContext),
     customDataRegistry,
-    apiListenerRegistry
+    apiListenerRegistry,
+    logger,
 )
 
 /**
@@ -168,9 +174,10 @@ object ContactsFactory {
     @JvmOverloads
     fun create(
         context: Context,
+        logger: Logger = EmptyLogger(),
         customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
         apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
-    ): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry)
+    ): Contacts = Contacts(context, logger, customDataRegistry, apiListenerRegistry)
 }
 
 private class ContactsImpl(
@@ -178,7 +185,8 @@ private class ContactsImpl(
     override val permissions: ContactsPermissions,
     override val accountsPermissions: AccountsPermissions,
     override val customDataRegistry: CustomDataRegistry,
-    override val apiListenerRegistry: CrudApiListenerRegistry
+    override val apiListenerRegistry: CrudApiListenerRegistry,
+    override var logger: Logger,
 ) : Contacts {
 
     override fun query() = Query(this)

--- a/core/src/main/java/contacts/core/Contacts.kt
+++ b/core/src/main/java/contacts/core/Contacts.kt
@@ -157,18 +157,9 @@ fun Contacts(
     customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
     apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry(),
     logger: Logger = EmptyLogger(),
-): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry, LoggerRegistry(logger))
-
-/**
- * Creates a new [Contacts] instance.
- */
-@Suppress("FunctionName")
-fun Contacts(
-    context: Context,
-    customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
-    apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry(),
-    loggerRegistry: LoggerRegistry = LoggerRegistry(),
-): Contacts = ContactsImpl(
+): Contacts {
+    val loggerRegistry = LoggerRegistry(logger)
+    return ContactsImpl(
         context.applicationContext,
         ContactsPermissions(context.applicationContext),
         AccountsPermissions(context.applicationContext),
@@ -176,6 +167,7 @@ fun Contacts(
         apiListenerRegistry.register(loggerRegistry.apiListener),
         loggerRegistry,
     )
+}
 
 /**
  * Creates a new [Contacts] instance.
@@ -193,14 +185,6 @@ object ContactsFactory {
         customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
         apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
     ): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry, logger)
-
-    @JvmStatic
-    fun create(
-        context: Context,
-        loggerRegistry: LoggerRegistry = LoggerRegistry(),
-        customDataRegistry: CustomDataRegistry = CustomDataRegistry(),
-        apiListenerRegistry: CrudApiListenerRegistry = CrudApiListenerRegistry()
-    ): Contacts = Contacts(context, customDataRegistry, apiListenerRegistry, loggerRegistry)
 }
 
 private class ContactsImpl(

--- a/core/src/main/java/contacts/core/log/Logger.kt
+++ b/core/src/main/java/contacts/core/log/Logger.kt
@@ -1,9 +1,21 @@
 package contacts.core.log
 
+import android.util.Log
+
 interface Logger {
   fun log(message: String)
 }
 
 class EmptyLogger : Logger {
   override fun log(message: String) {}
+}
+
+class AndroidLogger : Logger {
+  override fun log(message: String) {
+    Log.d(TAG, message)
+  }
+
+  companion object {
+    private const val TAG = "ContactsDebug"
+  }
 }

--- a/core/src/main/java/contacts/core/log/Logger.kt
+++ b/core/src/main/java/contacts/core/log/Logger.kt
@@ -1,0 +1,9 @@
+package contacts.core.log
+
+interface Logger {
+  fun log(message: String)
+}
+
+class EmptyLogger : Logger {
+  override fun log(message: String) {}
+}

--- a/core/src/main/java/contacts/core/log/Logger.kt
+++ b/core/src/main/java/contacts/core/log/Logger.kt
@@ -10,9 +10,9 @@ class EmptyLogger : Logger {
   override fun log(message: String) {}
 }
 
-class AndroidLogger : Logger {
+class AndroidLogger(private val tag: String = TAG) : Logger {
   override fun log(message: String) {
-    Log.d(TAG, message)
+    Log.d(tag, message)
   }
 
   companion object {

--- a/core/src/main/java/contacts/core/log/Logger.kt
+++ b/core/src/main/java/contacts/core/log/Logger.kt
@@ -3,14 +3,21 @@ package contacts.core.log
 import android.util.Log
 
 interface Logger {
+  val redactMessages: Boolean
+
   fun log(message: String)
 }
 
 class EmptyLogger : Logger {
+  override val redactMessages: Boolean = false
+
   override fun log(message: String) {}
 }
 
-class AndroidLogger(private val tag: String = TAG) : Logger {
+class AndroidLogger(
+  private val tag: String = TAG,
+  override val redactMessages: Boolean = true,
+) : Logger {
   override fun log(message: String) {
     Log.d(tag, message)
   }

--- a/core/src/main/java/contacts/core/log/LoggerRegistry.kt
+++ b/core/src/main/java/contacts/core/log/LoggerRegistry.kt
@@ -8,11 +8,13 @@ class LoggerRegistry @JvmOverloads constructor(
    private val logger: Logger = EmptyLogger(),
 ) {
 
-    internal val apiListener: CrudApi.Listener = Listener()
+    internal val apiListener: CrudApi.Listener = Listener(logger)
 
     // Prevent consumers from invoking the listener functions by not having the registry implement
     // it directly.
-    private inner class Listener : CrudApi.Listener {
+    private inner class Listener(
+        private val logger: Logger,
+    ) : CrudApi.Listener {
         override fun onPreExecute(api: CrudApi) {
             logRedactable(api)
         }

--- a/core/src/main/java/contacts/core/log/LoggerRegistry.kt
+++ b/core/src/main/java/contacts/core/log/LoggerRegistry.kt
@@ -6,7 +6,6 @@ import contacts.core.redactedCopyOrThis
 
 class LoggerRegistry @JvmOverloads constructor(
    private val logger: Logger = EmptyLogger(),
-   private val redactMessages: Boolean = true
 ) {
 
     internal val apiListener: CrudApi.Listener = Listener()
@@ -23,7 +22,7 @@ class LoggerRegistry @JvmOverloads constructor(
         }
 
         private fun logRedactable(redactable: Redactable) {
-            logger.log(redactable.redactedCopyOrThis(redactMessages).toString())
+            logger.log(redactable.redactedCopyOrThis(logger.redactMessages).toString())
         }
     }
 }

--- a/core/src/main/java/contacts/core/log/LoggerRegistry.kt
+++ b/core/src/main/java/contacts/core/log/LoggerRegistry.kt
@@ -1,0 +1,29 @@
+package contacts.core.log
+
+import contacts.core.CrudApi
+import contacts.core.Redactable
+import contacts.core.redactedCopyOrThis
+
+class LoggerRegistry @JvmOverloads constructor(
+   private val logger: Logger = EmptyLogger(),
+   private val redactMessages: Boolean = true
+) {
+
+    internal val apiListener: CrudApi.Listener = Listener()
+
+    // Prevent consumers from invoking the listener functions by not having the registry implement
+    // it directly.
+    private inner class Listener : CrudApi.Listener {
+        override fun onPreExecute(api: CrudApi) {
+            logRedactable(api)
+        }
+
+        override fun onPostExecute(result: CrudApi.Result) {
+            logRedactable(result)
+        }
+
+        private fun logRedactable(redactable: Redactable) {
+            logger.log(redactable.redactedCopyOrThis(redactMessages).toString())
+        }
+    }
+}

--- a/sample/src/main/java/contacts/sample/SampleApp.kt
+++ b/sample/src/main/java/contacts/sample/SampleApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import contacts.core.Contacts
 import contacts.core.entities.custom.CustomDataRegistry
 import contacts.core.log.AndroidLogger
+import contacts.core.log.LoggerRegistry
 import contacts.entities.custom.gender.GenderRegistration
 import contacts.entities.custom.handlename.HandleNameRegistration
 
@@ -18,7 +19,10 @@ class SampleApp : Application() {
         GenderRegistration(),
         HandleNameRegistration()
       ),
-      logger = AndroidLogger(),
+      loggerRegistry = LoggerRegistry(
+        logger = AndroidLogger(),
+        redactMessages = !BuildConfig.DEBUG, // Apps must provide it's own way to decide
+      ),
     )
   }
 }

--- a/sample/src/main/java/contacts/sample/SampleApp.kt
+++ b/sample/src/main/java/contacts/sample/SampleApp.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import contacts.core.Contacts
 import contacts.core.entities.custom.CustomDataRegistry
 import contacts.core.log.AndroidLogger
-import contacts.core.log.LoggerRegistry
 import contacts.entities.custom.gender.GenderRegistration
 import contacts.entities.custom.handlename.HandleNameRegistration
 
@@ -19,10 +18,7 @@ class SampleApp : Application() {
         GenderRegistration(),
         HandleNameRegistration()
       ),
-      loggerRegistry = LoggerRegistry(
-        logger = AndroidLogger(),
-        redactMessages = !BuildConfig.DEBUG, // Apps must provide it's own way to decide
-      ),
+      logger = AndroidLogger(),
     )
   }
 }

--- a/sample/src/main/java/contacts/sample/SampleApp.kt
+++ b/sample/src/main/java/contacts/sample/SampleApp.kt
@@ -3,20 +3,22 @@ package contacts.sample
 import android.app.Application
 import contacts.core.Contacts
 import contacts.core.entities.custom.CustomDataRegistry
+import contacts.core.log.AndroidLogger
 import contacts.entities.custom.gender.GenderRegistration
 import contacts.entities.custom.handlename.HandleNameRegistration
 
 class SampleApp : Application() {
 
-    // Obviously, this is not the way to provide a singleton when using dependency injection
-    // frameworks such as dagger, hilt, or koin. Again, this sample is made to be barebones!
-    val contacts: Contacts by lazy(LazyThreadSafetyMode.NONE) {
-        Contacts(
-            this,
-            CustomDataRegistry().register(
-                GenderRegistration(),
-                HandleNameRegistration()
-            )
-        )
-    }
+  // Obviously, this is not the way to provide a singleton when using dependency injection
+  // frameworks such as dagger, hilt, or koin. Again, this sample is made to be barebones!
+  val contacts: Contacts by lazy(LazyThreadSafetyMode.NONE) {
+    Contacts(
+      this,
+      customDataRegistry = CustomDataRegistry().register(
+        GenderRegistration(),
+        HandleNameRegistration()
+      ),
+      logger = AndroidLogger(),
+    )
+  }
 }

--- a/test/src/main/java/contacts/test/TestContacts.kt
+++ b/test/src/main/java/contacts/test/TestContacts.kt
@@ -22,7 +22,7 @@ import contacts.test.entities.TestDataRegistration
 fun TestContacts(
     context: Context,
     customDataRegistry: CustomDataRegistry = CustomDataRegistry()
-): Contacts = TestContacts(Contacts(context, customDataRegistry)).also {
+): Contacts = TestContacts(Contacts(context, EmptyLogger(), customDataRegistry)).also {
     customDataRegistry.register(TestDataRegistration())
 }
 

--- a/test/src/main/java/contacts/test/TestContacts.kt
+++ b/test/src/main/java/contacts/test/TestContacts.kt
@@ -1,11 +1,19 @@
 package contacts.test
 
 import android.content.Context
-import contacts.core.*
+import contacts.core.BroadQuery
+import contacts.core.Contacts
+import contacts.core.ContactsPermissions
+import contacts.core.Delete
+import contacts.core.Insert
+import contacts.core.Query
+import contacts.core.Update
 import contacts.core.accounts.Accounts
 import contacts.core.data.Data
 import contacts.core.entities.custom.CustomDataRegistry
 import contacts.core.groups.Groups
+import contacts.core.log.EmptyLogger
+import contacts.core.log.Logger
 import contacts.core.profile.Profile
 import contacts.test.entities.TestDataRegistration
 
@@ -36,6 +44,8 @@ object ContactsFactory {
  * TODO document this
  */
 private class TestContacts(private val contactsApi: Contacts) : Contacts {
+
+    override var logger: Logger = EmptyLogger()
 
     override fun query(): Query = TestQuery(contactsApi.query(), contactsApi)
 

--- a/test/src/main/java/contacts/test/TestContacts.kt
+++ b/test/src/main/java/contacts/test/TestContacts.kt
@@ -14,6 +14,7 @@ import contacts.core.entities.custom.CustomDataRegistry
 import contacts.core.groups.Groups
 import contacts.core.log.EmptyLogger
 import contacts.core.log.Logger
+import contacts.core.log.LoggerRegistry
 import contacts.core.profile.Profile
 import contacts.test.entities.TestDataRegistration
 
@@ -22,7 +23,7 @@ import contacts.test.entities.TestDataRegistration
 fun TestContacts(
     context: Context,
     customDataRegistry: CustomDataRegistry = CustomDataRegistry()
-): Contacts = TestContacts(Contacts(context, EmptyLogger(), customDataRegistry)).also {
+): Contacts = TestContacts(Contacts(context)).also {
     customDataRegistry.register(TestDataRegistration())
 }
 
@@ -45,7 +46,7 @@ object ContactsFactory {
  */
 private class TestContacts(private val contactsApi: Contacts) : Contacts {
 
-    override var logger: Logger = EmptyLogger()
+    override var loggerRegistry: LoggerRegistry = LoggerRegistry()
 
     override fun query(): Query = TestQuery(contactsApi.query(), contactsApi)
 


### PR DESCRIPTION
This PR adds `Logger` to `Contacts` API, so it can be used to track features like query, insert, ...

I not plan to add on this PR the logs to every feature, but my idea is to add it later following up a discussion with you about what and how should be tracked.

Code example with android logger:

```kotlin
val contacts = Contacts(
   context = this@Activity,
   logger = AndroidLogger(),
)
```

Code example with custom logger:
```kotlin
val contacts = Contacts(
   context = this@Activity,
   logger = object: Logger() {
      override fun log(message: String) {
          Timber.w() ...
      }
   },
)
```

This PR closes #144 