### PR TITLE
Closes #154 Standardize interface for CRUD APIs

### DIFF
--- a/core/src/main/java/contacts/core/CrudApi.kt
+++ b/core/src/main/java/contacts/core/CrudApi.kt
@@ -4,19 +4,16 @@ import android.content.ContentResolver
 import contacts.core.accounts.AccountsPermissions
 import contacts.core.entities.custom.CustomDataRegistry
 
+// ## Developer notes
+//
+// This should actually be an internal interface. It is public because public APIs implement this.
+// Anyways, this enforces some level of uniformity for all CRUD APIs. However, we should try to
+// keep the contract loose to allow for the most flexibility. Who knows? Consumers might find some
+// use for this. There is no howto page for this until we can find an official use for it.
+
 /**
  * All CRUD (Insert*, Query*, Update*, Delete*) APIs, accessible via a [Contacts], must implement
  * this interface.
- *
- * ## Developer notes
- *
- * This should actually be an internal interface. It is public because public APIs implement this.
- *
- * Anyways, this enforces some level of uniformity for all CRUD APIs. However, we should try to
- * keep the contract loose to allow for the most flexibility.
- *
- * Who knows? Consumers might find some use for this. There is no howto page for this until we can
- * find an official use for it.
  */
 interface CrudApi : Redactable {
 

--- a/core/src/main/java/contacts/core/CrudApi.kt
+++ b/core/src/main/java/contacts/core/CrudApi.kt
@@ -1,0 +1,138 @@
+package contacts.core
+
+import android.content.ContentResolver
+import contacts.core.accounts.AccountsPermissions
+import contacts.core.entities.custom.CustomDataRegistry
+
+/**
+ * All CRUD (Insert*, Query*, Update*, Delete*) APIs, accessible via a [Contacts], must implement
+ * this interface.
+ *
+ * ## Developer notes
+ *
+ * This should actually be an internal interface. It is public because public APIs implement this.
+ *
+ * Anyways, this enforces some level of uniformity for all CRUD APIs. However, we should try to
+ * keep the contract loose to allow for the most flexibility.
+ *
+ * Who knows? Consumers might find some use for this. There is no howto page for this until we can
+ * find an official use for it.
+ */
+interface CrudApi : Redactable {
+
+    /**
+     * A reference to the [Contacts] instance that constructed this. This is mostly used internally
+     * to shorten internal code.
+     *
+     * Don't worry, [Contacts] does not keep references to instances of this. There are no circular
+     * references that could cause leaks =). [Contacts] is just a factory.
+     */
+    val contactsApi: Contacts
+
+    /**
+     * The API core function result.
+     */
+    interface Result : Redactable
+
+    /**
+     * Get notified about events within [CrudApi] instances.
+     */
+    interface Listener {
+        /**
+         * Invoked by the [api] before executing its core function (e.g. "find" or "commit").
+         *
+         * ## Thread Safety
+         *
+         * This is invoked on the same thread as the thread the core function is invoked, which is
+         * determined by the consumer.
+         */
+        fun onPreExecute(api: CrudApi)
+
+        /**
+         * Invoked by the API after executing its core function (e.g. "find" or "commit") right
+         * before returning the [result] to the caller.
+         *
+         * ## Thread Safety
+         *
+         * This is invoked on the same thread as the thread the core function is invoked, which is
+         * determined by the consumer.
+         */
+        fun onPostExecute(result: Result)
+    }
+}
+
+/**
+ * Registry for all [CrudApi.Listener]s.
+ *
+ * This single instance of [CrudApi.Listener] per [Contacts] instance that will be used by all
+ * [CrudApi] instances.
+ */
+class CrudApiListenerRegistry {
+
+    private val listeners = mutableSetOf<CrudApi.Listener>()
+
+    /**
+     * Register a [listener] that will be notified about events on all CRUD APIs accessible via a
+     * [Contacts] instance.
+     *
+     * ## A short lesson about memory leaks <3
+     *
+     * Make sure to [unregister] the [listener] to prevent leaks! You only need to do this if the
+     * [listener] lifecycle is less than the lifecycle of the [Contacts] instance.
+     *
+     * For example, if your application is holding one instance of [Contacts] throughout the entire
+     * lifecycle of your [android.app.Application] (a singleton) and the [listener] passed here is
+     * (or contains a reference to) an `Activity`, `Fragment`, or `View`, then you must [unregister]
+     * the  [listener] before your Activity, Fragment, or View is destroyed. Otherwise, the
+     * reference to the Activity, Fragment, or View will remain in memory for as long as your
+     * `Application` is alive because there is a reference to it via this registry!
+     *
+     * However, if the [listener] does not have a reference to a non-Application `Context` or it
+     * is meant to have the same lifecycle as your [android.app.Application], then there is no need
+     * to [unregister].
+     */
+    fun register(listener: CrudApi.Listener): CrudApiListenerRegistry = apply {
+        listeners.add(listener)
+    }
+
+    /**
+     * Removes the [listener] from the registry.
+     *
+     * This is important for preventing memory leaks! Read more about it in the [register] function!
+     */
+    fun unregister(listener: CrudApi.Listener): CrudApiListenerRegistry = apply {
+        listeners.remove(listener)
+    }
+
+    internal fun onPreExecute(api: CrudApi) {
+        listeners.forEach { it.onPreExecute(api) }
+    }
+
+    internal fun onPostExecute(result: CrudApi.Result) {
+        listeners.forEach { it.onPostExecute(result) }
+    }
+}
+
+// region Shortcuts
+
+internal fun CrudApi.onPreExecute() {
+    contactsApi.apiListenerRegistry.onPreExecute(this)
+}
+
+internal fun CrudApi.Result.onPostExecute(contactsApi: Contacts) {
+    contactsApi.apiListenerRegistry.onPostExecute(this)
+}
+
+internal val CrudApi.permissions: ContactsPermissions
+    get() = contactsApi.permissions
+
+internal val CrudApi.accountsPermissions: AccountsPermissions
+    get() = contactsApi.accountsPermissions
+
+internal val CrudApi.contentResolver: ContentResolver
+    get() = contactsApi.contentResolver
+
+internal val CrudApi.customDataRegistry: CustomDataRegistry
+    get() = contactsApi.customDataRegistry
+
+// endregion

--- a/core/src/main/java/contacts/core/Include.kt
+++ b/core/src/main/java/contacts/core/Include.kt
@@ -59,9 +59,8 @@ internal class Include<out T : Field>(
     override fun toString(): String = columnNames.joinToString(", ")
 }
 
-internal fun allDataFields(
-    customDataRegistry: CustomDataRegistry
-): Include<AbstractDataField> = Include(Fields.all + customDataRegistry.allFields())
+internal fun Contacts.includeAllFields(): Include<AbstractDataField> =
+    Include(Fields.all + customDataRegistry.allFields())
 
 /**
  * Returns a new instance of [Include] where only [ContactsFields] in [this] are included.

--- a/core/src/main/java/contacts/core/accounts/Accounts.kt
+++ b/core/src/main/java/contacts/core/accounts/Accounts.kt
@@ -1,6 +1,5 @@
 package contacts.core.accounts
 
-import android.content.Context
 import contacts.core.Contacts
 
 /**
@@ -45,16 +44,13 @@ interface Accounts {
     fun profile(): Accounts
 
     /**
-     * Returns a [AccountsPermissions] instance, which provides functions for checking required
-     * permissions.
+     * A reference to the [Contacts] instance that constructed this. This is mostly used internally
+     * to shorten internal code.
+     *
+     * Don't worry, [Contacts] does not keep references to instances of this. There are no circular
+     * references that could cause leaks =). [Contacts] is just a factory.
      */
-    val permissions: AccountsPermissions
-
-    /**
-     * Reference to the Application's Context for use in extension functions and external library
-     * modules. This is safe to hold on to. Not meant for consumer use.
-     */
-    val applicationContext: Context
+    val contactsApi: Contacts
 }
 
 /**
@@ -62,24 +58,22 @@ interface Accounts {
  */
 @Suppress("FunctionName")
 internal fun Accounts(contacts: Contacts, isProfile: Boolean): Accounts = AccountsImpl(
-    contacts.applicationContext,
-    AccountsPermissions(contacts.applicationContext),
+    contacts,
     isProfile
 )
 
 @SuppressWarnings("MissingPermission")
 private class AccountsImpl(
-    override val applicationContext: Context,
-    override val permissions: AccountsPermissions,
+    override val contactsApi: Contacts,
     private val isProfile: Boolean
 ) : Accounts {
 
-    override fun query() = AccountsQuery(this, isProfile)
+    override fun query() = AccountsQuery(contactsApi, isProfile)
 
-    override fun queryRawContacts() = AccountsRawContactsQuery(this, isProfile)
+    override fun queryRawContacts() = AccountsRawContactsQuery(contactsApi, isProfile)
 
     override fun updateLocalRawContactsAccount() =
-        AccountsLocalRawContactsUpdate(this, isProfile)
+        AccountsLocalRawContactsUpdate(contactsApi, isProfile)
 
-    override fun profile(): Accounts = AccountsImpl(applicationContext, permissions, true)
+    override fun profile(): Accounts = AccountsImpl(contactsApi, true)
 }

--- a/core/src/main/java/contacts/core/data/Data.kt
+++ b/core/src/main/java/contacts/core/data/Data.kt
@@ -1,8 +1,6 @@
 package contacts.core.data
 
-import android.content.Context
 import contacts.core.Contacts
-import contacts.core.ContactsPermissions
 
 /**
  * Provides new [DataQueryFactory], [DataUpdate], and [DataDelete] for Profile OR non-Profile (depending on
@@ -40,33 +38,26 @@ interface Data {
     fun delete(): DataDelete
 
     /**
-     * Returns a [ContactsPermissions] instance, which provides functions for checking required
-     * permissions.
+     * A reference to the [Contacts] instance that constructed this. This is mostly used internally
+     * to shorten internal code.
+     *
+     * Don't worry, [Contacts] does not keep references to instances of this. There are no circular
+     * references that could cause leaks =). [Contacts] is just a factory.
      */
-    val permissions: ContactsPermissions
-
-    /**
-     * Reference to the Application's Context for use in extension functions and external library
-     * modules. This is safe to hold on to. Not meant for consumer use.
-     */
-    val applicationContext: Context
+    val contactsApi: Contacts
 }
 
 @Suppress("FunctionName")
 internal fun Data(contacts: Contacts, isProfile: Boolean): Data = DataImpl(contacts, isProfile)
 
 private class DataImpl(
-    private val contacts: Contacts,
+    override val contactsApi: Contacts,
     private val isProfile: Boolean
 ) : Data {
 
-    override fun query() = DataQuery(contacts, isProfile)
+    override fun query() = DataQuery(contactsApi, isProfile)
 
-    override fun update() = DataUpdate(contacts, isProfile)
+    override fun update() = DataUpdate(contactsApi, isProfile)
 
-    override fun delete() = DataDelete(contacts, isProfile)
-
-    override val permissions: ContactsPermissions = contacts.permissions
-
-    override val applicationContext: Context = contacts.applicationContext
+    override fun delete() = DataDelete(contactsApi, isProfile)
 }

--- a/core/src/main/java/contacts/core/entities/custom/CustomDataRegistry.kt
+++ b/core/src/main/java/contacts/core/entities/custom/CustomDataRegistry.kt
@@ -2,11 +2,14 @@ package contacts.core.entities.custom
 
 import contacts.core.AbstractCustomDataField
 import contacts.core.AbstractCustomDataFieldSet
+import contacts.core.Contacts
 import contacts.core.entities.*
 
 /**
  * Registry of custom data components, enabling queries, inserts, updates, and deletes for custom
  * data.
+ *
+ * There should only be a single instance of [CustomDataRegistry] per [Contacts] instance.
  */
 class CustomDataRegistry {
 
@@ -23,7 +26,7 @@ class CustomDataRegistry {
      * Register custom data [entries].
      */
     @SafeVarargs
-    fun register(vararg entries: Entry<*, *, *, *>) {
+    fun register(vararg entries: Entry<*, *, *, *>): CustomDataRegistry = apply {
         for (entry in entries) {
             @Suppress("UNCHECKED_CAST")
             entryMap[entry.mimeType.value] = entry as Entry<
@@ -37,7 +40,7 @@ class CustomDataRegistry {
     /**
      * Register custom data entries via the given [registrations].
      */
-    fun register(vararg registrations: EntryRegistration) {
+    fun register(vararg registrations: EntryRegistration): CustomDataRegistry = apply {
         for (registration in registrations) {
             registration.registerTo(this)
         }

--- a/core/src/main/java/contacts/core/groups/Groups.kt
+++ b/core/src/main/java/contacts/core/groups/Groups.kt
@@ -1,9 +1,7 @@
 package contacts.core.groups
 
-import android.content.Context
 import android.os.Build
 import contacts.core.Contacts
-import contacts.core.ContactsPermissions
 
 /**
  * Provides new [GroupsQuery], [GroupsInsert], [GroupsUpdate], and [GroupsDelete] instances.
@@ -44,36 +42,29 @@ interface Groups {
     fun delete(): GroupsDelete?
 
     /**
-     * Returns a [ContactsPermissions] instance, which provides functions for checking required
-     * permissions.
+     * A reference to the [Contacts] instance that constructed this. This is mostly used internally
+     * to shorten internal code.
+     *
+     * Don't worry, [Contacts] does not keep references to instances of this. There are no circular
+     * references that could cause leaks =). [Contacts] is just a factory.
      */
-    val permissions: ContactsPermissions
-
-    /**
-     * Reference to the Application's Context for use in extension functions and external library
-     * modules. This is safe to hold on to. Not meant for consumer use.
-     */
-    val applicationContext: Context
+    val contactsApi: Contacts
 }
 
 @Suppress("FunctionName")
 internal fun Groups(contacts: Contacts): Groups = GroupsImpl(contacts)
 
-private class GroupsImpl(private val contacts: Contacts) : Groups {
+private class GroupsImpl(override val contactsApi: Contacts) : Groups {
 
-    override fun query() = GroupsQuery(contacts)
+    override fun query() = GroupsQuery(contactsApi)
 
-    override fun insert() = GroupsInsert(contacts)
+    override fun insert() = GroupsInsert(contactsApi)
 
-    override fun update() = GroupsUpdate(contacts)
+    override fun update() = GroupsUpdate(contactsApi)
 
     override fun delete() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        GroupsDelete(contacts)
+        GroupsDelete(contactsApi)
     } else {
         null
     }
-
-    override val permissions: ContactsPermissions = contacts.permissions
-
-    override val applicationContext: Context = contacts.applicationContext
 }

--- a/core/src/main/java/contacts/core/profile/Profile.kt
+++ b/core/src/main/java/contacts/core/profile/Profile.kt
@@ -1,8 +1,6 @@
 package contacts.core.profile
 
-import android.content.Context
 import contacts.core.Contacts
-import contacts.core.ContactsPermissions
 import contacts.core.data.Data
 
 /**
@@ -47,34 +45,27 @@ interface Profile {
     fun data(): Data
 
     /**
-     * Returns a [ContactsPermissions] instance, which provides functions for checking required
-     * permissions.
+     * A reference to the [Contacts] instance that constructed this. This is mostly used internally
+     * to shorten internal code.
+     *
+     * Don't worry, [Contacts] does not keep references to instances of this. There are no circular
+     * references that could cause leaks =). [Contacts] is just a factory.
      */
-    val permissions: ContactsPermissions
-
-    /**
-     * Reference to the Application's Context for use in extension functions and external library
-     * modules. This is safe to hold on to. Not meant for consumer use.
-     */
-    val applicationContext: Context
+    val contactsApi: Contacts
 }
 
 @Suppress("FunctionName")
 internal fun Profile(contacts: Contacts): Profile = ProfileImpl(contacts)
 
-private class ProfileImpl(private val contacts: Contacts) : Profile {
+private class ProfileImpl(override val contactsApi: Contacts) : Profile {
 
-    override fun query() = ProfileQuery(contacts)
+    override fun query() = ProfileQuery(contactsApi)
 
-    override fun insert() = ProfileInsert(contacts)
+    override fun insert() = ProfileInsert(contactsApi)
 
-    override fun update() = ProfileUpdate(contacts)
+    override fun update() = ProfileUpdate(contactsApi)
 
-    override fun delete() = ProfileDelete(contacts)
+    override fun delete() = ProfileDelete(contactsApi)
 
-    override fun data() = Data(contacts, true)
-
-    override val permissions: ContactsPermissions = contacts.permissions
-
-    override val applicationContext: Context = contacts.applicationContext
+    override fun data() = Data(contactsApi, true)
 }

--- a/core/src/main/java/contacts/core/util/ContactOptions.kt
+++ b/core/src/main/java/contacts/core/util/ContactOptions.kt
@@ -36,7 +36,7 @@ fun ExistingContactEntity.options(contacts: Contacts): Options? {
         return null
     }
 
-    return contacts.applicationContext.contentResolver.query(
+    return contacts.contentResolver.query(
         if (isProfile) ProfileUris.CONTACTS.uri else Table.Contacts.uri,
         Include(ContactsFields.Options),
         ContactsFields.Id equalTo id
@@ -102,7 +102,7 @@ fun ExistingContactEntity.setOptions(contacts: Contacts, options: MutableOptions
         return false
     }
 
-    return contacts.applicationContext.contentResolver.applyBatch(
+    return contacts.contentResolver.applyBatch(
         OptionsOperation().updateContactOptions(id, options)
     ) != null
 }

--- a/core/src/main/java/contacts/core/util/ContactPhoto.kt
+++ b/core/src/main/java/contacts/core/util/ContactPhoto.kt
@@ -52,7 +52,7 @@ fun ExistingContactEntity.photoInputStream(contacts: Contacts): InputStream? {
         return null
     }
 
-    return contacts.applicationContext.contentResolver.query(
+    return contacts.contentResolver.query(
         if (isProfile) ProfileUris.CONTACTS.uri else Table.Contacts.uri,
         Include(ContactsFields.PhotoUri),
         ContactsFields.Id equalTo id
@@ -146,7 +146,7 @@ fun ExistingContactEntity.photoBitmap(contacts: Contacts): Bitmap? =
 // [ANDROID X] @WorkerThread (not using annotation to avoid dependency on androidx.annotation)
 fun ExistingContactEntity.photoBitmapDrawable(contacts: Contacts): BitmapDrawable? =
     photoInputStream(contacts)?.apply {
-        BitmapDrawable(contacts.applicationContext.resources, it)
+        BitmapDrawable(contacts.resources, it)
     }
 
 private fun uriInputStream(contacts: Contacts, uri: Uri?): InputStream? {
@@ -156,7 +156,7 @@ private fun uriInputStream(contacts: Contacts, uri: Uri?): InputStream? {
 
     var inputStream: InputStream? = null
     try {
-        val fd = contacts.applicationContext.contentResolver.openAssetFileDescriptor(uri, "r")
+        val fd = contacts.contentResolver.openAssetFileDescriptor(uri, "r")
         inputStream = fd?.createInputStream()
     } catch (ioe: IOException) {
         // do nothing
@@ -199,7 +199,7 @@ fun ExistingContactEntity.photoThumbnailInputStream(contacts: Contacts): InputSt
         return null
     }
 
-    return contacts.applicationContext.contentResolver.query(
+    return contacts.contentResolver.query(
         if (isProfile) ProfileUris.CONTACTS.uri else Table.Contacts.uri,
         Include(ContactsFields.PhotoThumbnailUri),
         ContactsFields.Id equalTo id
@@ -293,7 +293,7 @@ fun ExistingContactEntity.photoThumbnailBitmap(contacts: Contacts): Bitmap? =
 // [ANDROID X] @WorkerThread (not using annotation to avoid dependency on androidx.annotation)
 fun ExistingContactEntity.photoThumbnailBitmapDrawable(contacts: Contacts): BitmapDrawable? =
     photoThumbnailInputStream(contacts)?.apply {
-        BitmapDrawable(contacts.applicationContext.resources, it)
+        BitmapDrawable(contacts.resources, it)
     }
 
 // endregion
@@ -385,7 +385,7 @@ fun ExistingContactEntity.setPhoto(contacts: Contacts, photoDrawable: BitmapDraw
     setPhoto(contacts, photoDrawable.bitmap.bytes())
 
 private fun ExistingContactEntity.photoFileId(contacts: Contacts): Long? =
-    contacts.applicationContext.contentResolver.query(
+    contacts.contentResolver.query(
         if (isProfile) ProfileUris.CONTACTS.uri else Table.Contacts.uri,
         Include(ContactsFields.PhotoFileId),
         ContactsFields.Id equalTo id
@@ -395,14 +395,13 @@ private fun ExistingContactEntity.photoFileId(contacts: Contacts): Long? =
 
 private fun ExistingContactEntity.rawContactWithPhotoFileId(
     contacts: Contacts, photoFileId: Long
-): TempRawContact? =
-    contacts.applicationContext.contentResolver.query(
-        if (isProfile) ProfileUris.DATA.uri else Table.Data.uri,
-        Include(Fields.RawContact.Id),
-        Fields.Photo.PhotoFileId equalTo photoFileId
-    ) {
-        it.getNextOrNull { it.dataCursor().tempRawContactMapper().value }
-    }
+): TempRawContact? = contacts.contentResolver.query(
+    if (isProfile) ProfileUris.DATA.uri else Table.Data.uri,
+    Include(Fields.RawContact.Id),
+    Fields.Photo.PhotoFileId equalTo photoFileId
+) {
+    it.getNextOrNull { it.dataCursor().tempRawContactMapper().value }
+}
 
 // endregion
 
@@ -445,7 +444,7 @@ fun ExistingContactEntity.removePhoto(contacts: Contacts): Boolean {
         return false
     }
 
-    return contacts.applicationContext.contentResolver.applyBatch(
+    return contacts.contentResolver.applyBatch(
         newDelete(if (isProfile) ProfileUris.DATA.uri else Table.Data.uri)
             .withSelection(
                 (Fields.Contact.Id equalTo id)

--- a/core/src/main/java/contacts/core/util/DefaultContactData.kt
+++ b/core/src/main/java/contacts/core/util/DefaultContactData.kt
@@ -55,7 +55,7 @@ fun ExistingDataEntity.setAsDefault(contacts: Contacts): Boolean {
         return false
     }
 
-    return contacts.applicationContext.contentResolver.applyBatch(
+    return contacts.contentResolver.applyBatch(
         clearPrimary(rawContactId),
         clearSuperPrimary(contactId),
         setPrimaryAndSuperPrimary(dataId)
@@ -111,7 +111,7 @@ fun ExistingDataEntity.clearDefault(contactsApi: Contacts): Boolean {
         return false
     }
 
-    return contactsApi.applicationContext.contentResolver.applyBatch(
+    return contactsApi.contentResolver.applyBatch(
         clearPrimary(rawContactId),
         clearSuperPrimary(contactId)
     ) != null

--- a/core/src/main/java/contacts/core/util/RawContactOptions.kt
+++ b/core/src/main/java/contacts/core/util/RawContactOptions.kt
@@ -1,10 +1,10 @@
 package contacts.core.util
 
 import contacts.core.*
-import contacts.core.entities.Options
 import contacts.core.entities.ExistingRawContactEntity
 import contacts.core.entities.MutableOptionsEntity
 import contacts.core.entities.NewOptions
+import contacts.core.entities.Options
 import contacts.core.entities.mapper.rawContactsOptionsMapper
 import contacts.core.entities.operation.OptionsOperation
 import contacts.core.entities.table.ProfileUris
@@ -35,7 +35,7 @@ fun ExistingRawContactEntity.options(contacts: Contacts): Options? {
         return null
     }
 
-    return contacts.applicationContext.contentResolver.query(
+    return contacts.contentResolver.query(
         if (isProfile) ProfileUris.RAW_CONTACTS.uri else Table.RawContacts.uri,
         Include(RawContactsFields.Options),
         RawContactsFields.Id equalTo id
@@ -104,7 +104,7 @@ fun ExistingRawContactEntity.setOptions(
         return false
     }
 
-    return contacts.applicationContext.contentResolver.applyBatch(
+    return contacts.contentResolver.applyBatch(
         OptionsOperation().updateRawContactOptions(id, options)
     ) != null
 }

--- a/core/src/main/java/contacts/core/util/RawContactPhoto.kt
+++ b/core/src/main/java/contacts/core/util/RawContactPhoto.kt
@@ -53,7 +53,7 @@ fun ExistingRawContactEntity.photoInputStream(contacts: Contacts): InputStream? 
 
     var inputStream: InputStream? = null
     try {
-        val fd = contacts.applicationContext.contentResolver.openAssetFileDescriptor(photoUri, "r")
+        val fd = contacts.contentResolver.openAssetFileDescriptor(photoUri, "r")
         inputStream = fd?.createInputStream()
     } catch (ioe: IOException) {
         // do nothing
@@ -124,7 +124,7 @@ fun ExistingRawContactEntity.photoBitmap(contacts: Contacts): Bitmap? =
 // [ANDROID X] @WorkerThread (not using annotation to avoid dependency on androidx.annotation)
 fun ExistingRawContactEntity.photoBitmapDrawable(contacts: Contacts): BitmapDrawable? =
     photoInputStream(contacts)?.apply {
-        BitmapDrawable(contacts.applicationContext.resources, it)
+        BitmapDrawable(contacts.resources, it)
     }
 
 internal inline fun <T> InputStream.apply(block: (InputStream) -> T): T {
@@ -161,7 +161,7 @@ fun ExistingRawContactEntity.photoThumbnailInputStream(contacts: Contacts): Inpu
         return null
     }
 
-    return contacts.applicationContext.contentResolver.query(
+    return contacts.contentResolver.query(
         if (isProfile) ProfileUris.DATA.uri else Table.Data.uri,
         Include(Fields.Photo.PhotoThumbnail),
         (Fields.RawContact.Id equalTo id)
@@ -235,7 +235,7 @@ fun ExistingRawContactEntity.photoThumbnailBitmap(contacts: Contacts): Bitmap? =
 // [ANDROID X] @WorkerThread (not using annotation to avoid dependency on androidx.annotation)
 fun ExistingRawContactEntity.photoThumbnailBitmapDrawable(contacts: Contacts): BitmapDrawable? =
     photoThumbnailInputStream(contacts)?.apply {
-        BitmapDrawable(contacts.applicationContext.resources, it)
+        BitmapDrawable(contacts.resources, it)
     }
 
 // endregion
@@ -328,7 +328,7 @@ internal fun Contacts.setRawContactPhoto(
         // Didn't want to force unwrap because I'm trying to keep the codebase free of it.
         // I wanted to fold the if-return using ?: but it results in a lint error about unreachable
         // code (it's not unreachable).
-        val fd = applicationContext.contentResolver
+        val fd = contentResolver
             .openAssetFileDescriptor(photoUri, "rw")
         if (fd != null) {
             val os = fd.createOutputStream()
@@ -393,7 +393,7 @@ fun ExistingRawContactEntity.removePhoto(contacts: Contacts): Boolean {
         return false
     }
 
-    return contacts.applicationContext.contentResolver.applyBatch(
+    return contacts.contentResolver.applyBatch(
         newDelete(if (isProfile) ProfileUris.DATA.uri else Table.Data.uri)
             .withSelection(
                 (Fields.RawContact.Id equalTo id)

--- a/permissions/src/main/java/contacts/permissions/accounts/AccountsPermissionsRequest.kt
+++ b/permissions/src/main/java/contacts/permissions/accounts/AccountsPermissionsRequest.kt
@@ -16,8 +16,8 @@ import contacts.permissions.requestWritePermission
  * If permissions are already granted, then immediately returns a new [AccountsQuery] instance.
  */
 suspend fun Accounts.queryWithPermission(): AccountsQuery {
-    if (!permissions.canQueryAccounts()) {
-        applicationContext.requestQueryAccountsPermission()
+    if (!contactsApi.accountsPermissions.canQueryAccounts()) {
+        contactsApi.applicationContext.requestQueryAccountsPermission()
     }
 
     return query()
@@ -31,8 +31,8 @@ suspend fun Accounts.queryWithPermission(): AccountsQuery {
  * instance.
  */
 suspend fun Accounts.queryRawContactsWithPermission(): AccountsRawContactsQuery {
-    if (!permissions.canQueryRawContacts()) {
-        applicationContext.requestQueryRawContactsPermission()
+    if (!contactsApi.accountsPermissions.canQueryRawContacts()) {
+        contactsApi.applicationContext.requestQueryRawContactsPermission()
     }
 
     return queryRawContacts()
@@ -48,8 +48,8 @@ suspend fun Accounts.queryRawContactsWithPermission(): AccountsRawContactsQuery 
  */
 suspend fun Accounts.updateLocalRawContactsAccountWithPermission():
         AccountsLocalRawContactsUpdate {
-    if (!permissions.canUpdateLocalRawContactsAccount()) {
-        applicationContext.requestUpdateLocalRawContactsAccountPermission()
+    if (!contactsApi.accountsPermissions.canUpdateLocalRawContactsAccount()) {
+        contactsApi.applicationContext.requestUpdateLocalRawContactsAccountPermission()
     }
 
     return updateLocalRawContactsAccount()

--- a/permissions/src/main/java/contacts/permissions/data/DataPermissionsRequest.kt
+++ b/permissions/src/main/java/contacts/permissions/data/DataPermissionsRequest.kt
@@ -15,8 +15,8 @@ import contacts.permissions.requestWritePermission
  * If permission is already granted, then immediately returns a new [DataQueryFactory] instance.
  */
 suspend fun Data.queryWithPermission(): DataQueryFactory {
-    if (!permissions.canQuery()) {
-        applicationContext.requestReadPermission()
+    if (!contactsApi.permissions.canQuery()) {
+        contactsApi.applicationContext.requestReadPermission()
     }
 
     return query()
@@ -29,8 +29,8 @@ suspend fun Data.queryWithPermission(): DataQueryFactory {
  * If permission is already granted, then immediately returns a new [DataUpdate] instance.
  */
 suspend fun Data.updateWithPermission(): DataUpdate {
-    if (!permissions.canUpdateDelete()) {
-        applicationContext.requestWritePermission()
+    if (!contactsApi.permissions.canUpdateDelete()) {
+        contactsApi.applicationContext.requestWritePermission()
     }
 
     return update()
@@ -43,8 +43,8 @@ suspend fun Data.updateWithPermission(): DataUpdate {
  * If permissions are already granted, then immediately returns a new [DataDelete] instance.
  */
 suspend fun Data.deleteWithPermission(): DataDelete {
-    if (!permissions.canUpdateDelete()) {
-        applicationContext.requestWritePermission()
+    if (!contactsApi.permissions.canUpdateDelete()) {
+        contactsApi.applicationContext.requestWritePermission()
     }
 
     return delete()

--- a/permissions/src/main/java/contacts/permissions/groups/GroupsPermissionsRequest.kt
+++ b/permissions/src/main/java/contacts/permissions/groups/GroupsPermissionsRequest.kt
@@ -13,8 +13,8 @@ import contacts.permissions.requestWritePermission
  * If permission is already granted, then immediately returns a new [GroupsQuery] instance.
  */
 suspend fun Groups.queryWithPermission(): GroupsQuery {
-    if (!permissions.canQuery()) {
-        applicationContext.requestReadPermission()
+    if (!contactsApi.permissions.canQuery()) {
+        contactsApi.applicationContext.requestReadPermission()
     }
 
     return query()
@@ -29,9 +29,9 @@ suspend fun Groups.queryWithPermission(): GroupsQuery {
  * If permissions are already granted, then immediately returns a new [GroupsInsert] instance.
  */
 suspend fun Groups.insertWithPermission(): GroupsInsert {
-    if (!permissions.canInsert()) {
-        applicationContext.requestWritePermission()
-        applicationContext.requestGetAccountsPermission()
+    if (!contactsApi.permissions.canInsert()) {
+        contactsApi.applicationContext.requestWritePermission()
+        contactsApi.applicationContext.requestGetAccountsPermission()
     }
 
     return insert()
@@ -44,8 +44,8 @@ suspend fun Groups.insertWithPermission(): GroupsInsert {
  * If permissions are already granted, then immediately returns a new [GroupsUpdate] instance.
  */
 suspend fun Groups.updateWithPermission(): GroupsUpdate {
-    if (!permissions.canUpdateDelete()) {
-        applicationContext.requestWritePermission()
+    if (!contactsApi.permissions.canUpdateDelete()) {
+        contactsApi.applicationContext.requestWritePermission()
     }
 
     return update()
@@ -58,8 +58,8 @@ suspend fun Groups.updateWithPermission(): GroupsUpdate {
  * If permissions are already granted, then immediately returns a new [GroupsDelete] instance.
  */
 suspend fun Groups.deleteWithPermission(): GroupsDelete? {
-    if (!permissions.canUpdateDelete()) {
-        applicationContext.requestWritePermission()
+    if (!contactsApi.permissions.canUpdateDelete()) {
+        contactsApi.applicationContext.requestWritePermission()
     }
 
     return delete()

--- a/permissions/src/main/java/contacts/permissions/profile/ProfilePermissionsRequest.kt
+++ b/permissions/src/main/java/contacts/permissions/profile/ProfilePermissionsRequest.kt
@@ -13,8 +13,8 @@ import contacts.permissions.requestWritePermission
  * If permission is already granted, then immediately returns a new [ProfileQuery] instance.
  */
 suspend fun Profile.queryWithPermission(): ProfileQuery {
-    if (!permissions.canQuery()) {
-        applicationContext.requestReadPermission()
+    if (!contactsApi.permissions.canQuery()) {
+        contactsApi.applicationContext.requestReadPermission()
     }
 
     return query()
@@ -29,9 +29,9 @@ suspend fun Profile.queryWithPermission(): ProfileQuery {
  * If permission is already granted, then immediately returns a new [ProfileInsert] instance.
  */
 suspend fun Profile.insertWithPermission(): ProfileInsert {
-    if (!permissions.canInsert()) {
-        applicationContext.requestWritePermission()
-        applicationContext.requestGetAccountsPermission()
+    if (!contactsApi.permissions.canInsert()) {
+        contactsApi.applicationContext.requestWritePermission()
+        contactsApi.applicationContext.requestGetAccountsPermission()
     }
 
     return insert()
@@ -44,8 +44,8 @@ suspend fun Profile.insertWithPermission(): ProfileInsert {
  * If permission is already granted, then immediately returns a new [ProfileUpdate] instance.
  */
 suspend fun Profile.updateWithPermission(): ProfileUpdate {
-    if (!permissions.canUpdateDelete()) {
-        applicationContext.requestWritePermission()
+    if (!contactsApi.permissions.canUpdateDelete()) {
+        contactsApi.applicationContext.requestWritePermission()
     }
 
     return update()
@@ -58,8 +58,8 @@ suspend fun Profile.updateWithPermission(): ProfileUpdate {
  * If permission is already granted, then immediately returns a new [ProfileDelete] instance.
  */
 suspend fun Profile.deleteWithPermission(): ProfileDelete {
-    if (!permissions.canUpdateDelete()) {
-        applicationContext.requestWritePermission()
+    if (!contactsApi.permissions.canUpdateDelete()) {
+        contactsApi.applicationContext.requestWritePermission()
     }
 
     return delete()

--- a/sample/src/main/java/contacts/sample/SampleApp.kt
+++ b/sample/src/main/java/contacts/sample/SampleApp.kt
@@ -13,12 +13,10 @@ class SampleApp : Application() {
     val contacts: Contacts by lazy(LazyThreadSafetyMode.NONE) {
         Contacts(
             this,
-            CustomDataRegistry().apply {
-                register(
-                    GenderRegistration(),
-                    HandleNameRegistration()
-                )
-            }
+            CustomDataRegistry().register(
+                GenderRegistration(),
+                HandleNameRegistration()
+            )
         )
     }
 }

--- a/test/src/main/java/contacts/test/TestContacts.kt
+++ b/test/src/main/java/contacts/test/TestContacts.kt
@@ -35,9 +35,9 @@ object ContactsFactory {
 /**
  * TODO document this
  */
-private class TestContacts(private val contacts: Contacts) : Contacts {
+private class TestContacts(private val contactsApi: Contacts) : Contacts {
 
-    override fun query(): Query = TestQuery(contacts.query())
+    override fun query(): Query = TestQuery(contactsApi.query(), contactsApi)
 
     override fun broadQuery(): BroadQuery {
         TODO("Not yet implemented")
@@ -73,9 +73,13 @@ private class TestContacts(private val contacts: Contacts) : Contacts {
         TODO("Not yet implemented")
     }
 
-    override val permissions: ContactsPermissions = contacts.permissions
+    override val permissions = contactsApi.permissions
 
-    override val applicationContext: Context = contacts.applicationContext
+    override val accountsPermissions = contactsApi.accountsPermissions
 
-    override val customDataRegistry: CustomDataRegistry = contacts.customDataRegistry
+    override val applicationContext = contactsApi.applicationContext
+
+    override val customDataRegistry = contactsApi.customDataRegistry
+
+    override val apiListenerRegistry = contactsApi.apiListenerRegistry
 }

--- a/test/src/main/java/contacts/test/TestQuery.kt
+++ b/test/src/main/java/contacts/test/TestQuery.kt
@@ -14,12 +14,13 @@ import contacts.test.entities.TestDataFields
  */
 internal class TestQuery(
     private val query: Query,
+    override val contactsApi: Contacts,
     override val isRedacted: Boolean = false
 ) : Query {
 
     override fun toString(): String = query.toString()
 
-    override fun redactedCopy() = TestQuery(query.redactedCopy(), isRedacted = true)
+    override fun redactedCopy() = TestQuery(query.redactedCopy(), contactsApi, isRedacted = true)
 
     override fun includeBlanks(includeBlanks: Boolean): TestQuery = apply {
         query.includeBlanks(includeBlanks)


### PR DESCRIPTION
In addition to implementing the `CrudApi` interface as specified in #154, I also did the following in this PR;

- Added the `CrudApiListenerRegistry`. 
    - This is actually a new feature but I won't be advertising this to consumers until we find a more official, useful use for it.
    - Therefore, the label of this PR does not include "enhancement" and there is no howto page for it.
- `CrudApi`s must have a reference to the `Contacts` API instance that created it.
    - This clean up a lot of internal code.